### PR TITLE
pt concordances, placetype local, and more

### DIFF
--- a/data/151/161/489/1/1511614891.geojson
+++ b/data/151/161/489/1/1511614891.geojson
@@ -5,6 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.242043,
+    "geom:area_square_m":2347122157.795866,
     "geom:bbox":"-31.268219,36.929466,-25.013609,39.726104",
     "geom:latitude":38.34732,
     "geom:longitude":-27.279976,
@@ -398,12 +399,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"PT.AC",
+        "iso:code":"PT-20",
+        "qs:local_id":"200",
         "wd:id":"Q25263",
         "wk:page":"Azores"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"PT",
     "wof:created":1576262053,
-    "wof:geomhash":"1120122aafad7f9e9d7efeeb16d694a7",
+    "wof:geomhash":"d775081dc8e34d815fe158ac9f81d9c0",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -418,7 +425,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690856148,
+    "wof:lastmodified":1695884756,
     "wof:name":"Azores",
     "wof:parent_id":85633735,
     "wof:placetype":"region",

--- a/data/151/161/489/3/1511614893.geojson
+++ b/data/151/161/489/3/1511614893.geojson
@@ -5,6 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.077398,
+    "geom:area_square_m":804905586.198652,
     "geom:bbox":"-17.265785,30.136984,-15.854782,33.107342",
     "geom:latitude":32.750432,
     "geom:longitude":-16.949819,
@@ -401,12 +402,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"PT.MA",
+        "iso:code":"PT-30",
+        "qs:local_id":"300",
         "wd:id":"Q26253",
         "wk:page":"Madeira"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"PT",
     "wof:created":1576262054,
-    "wof:geomhash":"fdd422c96c70ff056df7da9e4decdff3",
+    "wof:geomhash":"2aef86abf3f0664af48b4edd3d505f32",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -421,7 +428,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690856149,
+    "wof:lastmodified":1695884946,
     "wof:name":"Madeira",
     "wof:parent_id":85633735,
     "wof:placetype":"region",

--- a/data/856/337/35/85633735.geojson
+++ b/data/856/337/35/85633735.geojson
@@ -1339,6 +1339,7 @@
         "gp:id":23424925,
         "hasc:id":"PT",
         "ioc:id":"POR",
+        "iso:code":"PT",
         "itu:id":"POR",
         "loc:id":"n80049716",
         "m49:code":"620",
@@ -1353,6 +1354,7 @@
         "wk:page":"Portugal",
         "wmo:id":"PO"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PT",
     "wof:country_alpha3":"PRT",
     "wof:geom_alt":[
@@ -1375,7 +1377,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1694492245,
+    "wof:lastmodified":1695881358,
     "wof:name":"Portugal",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/873/49/85687349.geojson
+++ b/data/856/873/49/85687349.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.508913,
-    "geom:area_square_m":5009524490.032086,
+    "geom:area_square_m":5009523751.794325,
     "geom:bbox":"-8.995174,36.960426,-7.401917,37.529097",
     "geom:latitude":37.243248,
     "geom:longitude":-8.131896,
@@ -335,12 +335,18 @@
         "gn:id":2268337,
         "gp:id":2346569,
         "hasc:id":"PT.FA",
+        "iso:code":"PT-08",
         "iso:id":"PT-08",
+        "qs:local_id":"108",
         "unlc:id":"PT-08",
         "wd:id":"Q244521"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"PT",
-    "wof:geomhash":"3ce4df8d19615552da7d5e387a3a569c",
+    "wof:geomhash":"9a4c848a3c3fa5c689d31489ff9704ef",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -355,7 +361,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690856163,
+    "wof:lastmodified":1695884406,
     "wof:name":"Faro",
     "wof:parent_id":85633735,
     "wof:placetype":"region",

--- a/data/856/873/55/85687355.geojson
+++ b/data/856/873/55/85687355.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.050348,
-    "geom:area_square_m":10258118686.133184,
+    "geom:area_square_m":10258119423.583294,
     "geom:bbox":"-8.820327,37.318969,-6.931739,38.331105",
     "geom:latitude":37.829689,
     "geom:longitude":-7.944052,
@@ -362,12 +362,18 @@
         "gn:id":2270984,
         "gp:id":2346563,
         "hasc:id":"PT.BE",
+        "iso:code":"PT-02",
         "iso:id":"PT-02",
+        "qs:local_id":"102",
         "unlc:id":"PT-02",
         "wd:id":"Q321455"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"PT",
-    "wof:geomhash":"062967e6b96d9281bd09c65fbbf3cbca",
+    "wof:geomhash":"a8b0b74a00bafeaaf4cdcbd000c63bb7",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -382,7 +388,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690856161,
+    "wof:lastmodified":1695884405,
     "wof:name":"Beja",
     "wof:parent_id":85633735,
     "wof:placetype":"region",

--- a/data/856/873/59/85687359.geojson
+++ b/data/856/873/59/85687359.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.538195,
-    "geom:area_square_m":5221150755.124365,
+    "geom:area_square_m":5221151342.237071,
     "geom:bbox":"-9.260374,37.749334,-8.129698,38.84542",
     "geom:latitude":38.319226,
     "geom:longitude":-8.653526,
@@ -335,12 +335,18 @@
         "gn:id":2262961,
         "gp:id":2346577,
         "hasc:id":"PT.SE",
+        "iso:code":"PT-15",
         "iso:id":"PT-15",
+        "qs:local_id":"115",
         "unlc:id":"PT-15",
         "wd:id":"Q274109"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"PT",
-    "wof:geomhash":"305a6d22d177112f11ab09f084dbf2c2",
+    "wof:geomhash":"bce877d899d37dc2dbe7ea8d953c8b36",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -355,7 +361,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690856159,
+    "wof:lastmodified":1695884406,
     "wof:name":"Set\u00fabal",
     "wof:parent_id":85633735,
     "wof:placetype":"region",

--- a/data/856/873/63/85687363.geojson
+++ b/data/856/873/63/85687363.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.764898,
-    "geom:area_square_m":7391274627.714731,
+    "geom:area_square_m":7391274252.849092,
     "geom:bbox":"-8.658445,38.154653,-7.107271,39.02693",
     "geom:latitude":38.603859,
     "geom:longitude":-7.841552,
@@ -341,12 +341,18 @@
         "gn:id":2268404,
         "gp:id":2346568,
         "hasc:id":"PT.EV",
+        "iso:code":"PT-07",
         "iso:id":"PT-07",
+        "qs:local_id":"107",
         "unlc:id":"PT-07",
         "wd:id":"Q274118"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"PT",
-    "wof:geomhash":"8fe912d40e19f70e10a685509b29aa4d",
+    "wof:geomhash":"917834801e78b411b251354ec636e0ca",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -361,7 +367,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690856162,
+    "wof:lastmodified":1695884406,
     "wof:name":"\u00c9vora",
     "wof:parent_id":85633735,
     "wof:placetype":"region",

--- a/data/856/873/67/85687367.geojson
+++ b/data/856/873/67/85687367.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.291119,
-    "geom:area_square_m":2797579502.872366,
+    "geom:area_square_m":2797580043.249197,
     "geom:bbox":"-9.500469,38.673057,-8.781865,39.317726",
     "geom:latitude":38.998275,
     "geom:longitude":-9.163635,
@@ -312,12 +312,18 @@
         "gn:id":2267056,
         "gp:id":2346573,
         "hasc:id":"PT.LI",
+        "iso:code":"PT-11",
         "iso:id":"PT-11",
+        "qs:local_id":"111",
         "unlc:id":"PT-11",
         "wd:id":"Q207199"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"PT",
-    "wof:geomhash":"f821d1cee1c6add3df038231c09a64ab",
+    "wof:geomhash":"3137474438bb5d0a9a6d6dd24c5e6030",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -332,7 +338,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690856160,
+    "wof:lastmodified":1695884946,
     "wof:name":"Lisboa",
     "wof:parent_id":85633735,
     "wof:placetype":"region",

--- a/data/856/873/73/85687373.geojson
+++ b/data/856/873/73/85687373.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.634225,
-    "geom:area_square_m":6078189816.075514,
+    "geom:area_square_m":6078190328.4968,
     "geom:bbox":"-8.343874,38.750611,-6.951392,39.663552",
     "geom:latitude":39.189953,
     "geom:longitude":-7.620444,
@@ -294,12 +294,18 @@
         "gn:id":2264507,
         "gp:id":2346574,
         "hasc:id":"PT.PA",
+        "iso:code":"PT-12",
         "iso:id":"PT-12",
+        "qs:local_id":"112",
         "unlc:id":"PT-12",
         "wd:id":"Q225189"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"PT",
-    "wof:geomhash":"bcdd7af72374d0ece6f2fb236e8c5cfc",
+    "wof:geomhash":"7d66d75322aabe0eb67efa6b619efab3",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -314,7 +320,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690856160,
+    "wof:lastmodified":1695884946,
     "wof:name":"Portalegre",
     "wof:parent_id":85633735,
     "wof:placetype":"region",

--- a/data/856/873/77/85687377.geojson
+++ b/data/856/873/77/85687377.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.701422,
-    "geom:area_square_m":6712240111.827819,
+    "geom:area_square_m":6712239840.266274,
     "geom:bbox":"-9.001579,38.731491,-7.808993,39.838523",
     "geom:latitude":39.293487,
     "geom:longitude":-8.477571,
@@ -356,12 +356,18 @@
         "gn:id":2263478,
         "gp:id":2346576,
         "hasc:id":"PT.SA",
+        "iso:code":"PT-14",
         "iso:id":"PT-14",
+        "qs:local_id":"114",
         "unlc:id":"PT-14",
         "wd:id":"Q244510"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"PT",
-    "wof:geomhash":"5cd195187ff0fdbac009f6b6663e209b",
+    "wof:geomhash":"011bd7f7ca418d9de85e27eeb5505575",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -376,7 +382,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690856162,
+    "wof:lastmodified":1695884406,
     "wof:name":"Santar\u00e9m",
     "wof:parent_id":85633735,
     "wof:placetype":"region",

--- a/data/856/873/81/85687381.geojson
+++ b/data/856/873/81/85687381.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.368384,
-    "geom:area_square_m":3502906870.119562,
+    "geom:area_square_m":3503823584.215077,
     "geom:bbox":"-9.516709,39.211523,-8.108054,40.089735",
     "geom:latitude":39.71729,
     "geom:longitude":-8.775334,
@@ -265,13 +265,19 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "iso:code":"PT-10",
+        "qs:local_id":"110",
         "wd:id":"Q244512"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"PT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bbdc036bf19028f5c9d716eb05b8be31",
+    "wof:geomhash":"437d5766e47adc1f238336e181ebb25f",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -286,7 +292,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690856161,
+    "wof:lastmodified":1695884946,
     "wof:name":"Leiria",
     "wof:parent_id":85633735,
     "wof:placetype":"region",

--- a/data/856/873/85/85687385.geojson
+++ b/data/856/873/85/85687385.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.697959,
-    "geom:area_square_m":6616394632.225394,
+    "geom:area_square_m":6616393881.206687,
     "geom:bbox":"-8.293027,39.537363,-6.864203,40.41613",
     "geom:latitude":39.946636,
     "geom:longitude":-7.501777,
@@ -338,12 +338,18 @@
         "gn:id":2269513,
         "gp:id":2346566,
         "hasc:id":"PT.CB",
+        "iso:code":"PT-05",
         "iso:id":"PT-05",
+        "qs:local_id":"105",
         "unlc:id":"PT-05",
         "wd:id":"Q273529"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"PT",
-    "wof:geomhash":"bf098376a38b709f11aeca429305645a",
+    "wof:geomhash":"74e7af97f515ec17d1eed260a20bf0d3",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -358,7 +364,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690856163,
+    "wof:lastmodified":1695884947,
     "wof:name":"Castelo Branco",
     "wof:parent_id":85633735,
     "wof:placetype":"region",

--- a/data/856/873/91/85687391.geojson
+++ b/data/856/873/91/85687391.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.42043,
-    "geom:area_square_m":3970475320.281852,
+    "geom:area_square_m":3970475217.982194,
     "geom:bbox":"-8.908637,39.92379,-7.731759,40.519169",
     "geom:latitude":40.204398,
     "geom:longitude":-8.336057,
@@ -325,12 +325,18 @@
         "gn:id":2740636,
         "gp:id":2346567,
         "hasc:id":"PT.CO",
+        "iso:code":"PT-06",
         "iso:id":"PT-06",
+        "qs:local_id":"106",
         "unlc:id":"PT-06",
         "wd:id":"Q244517"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"PT",
-    "wof:geomhash":"24ffec92b979494b8b565b714bdad03e",
+    "wof:geomhash":"e77321733983b217556f45414d368d77",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -345,7 +351,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690856161,
+    "wof:lastmodified":1695884946,
     "wof:name":"Coimbra",
     "wof:parent_id":85633735,
     "wof:placetype":"region",

--- a/data/856/873/97/85687397.geojson
+++ b/data/856/873/97/85687397.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.588975,
-    "geom:area_square_m":5512513978.677454,
+    "geom:area_square_m":5526153566.595988,
     "geom:bbox":"-7.849229,40.229917,-6.781048,41.17935",
     "geom:latitude":40.641271,
     "geom:longitude":-7.229737,
@@ -336,14 +336,20 @@
         "gn:id":2738782,
         "gp:id":2346571,
         "hasc:id":"PT.GU",
+        "iso:code":"PT-09",
         "iso:id":"PT-09",
+        "qs:local_id":"109",
         "wd:id":"Q273533"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"PT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"596e0251160fa25398bdd0e232817d22",
+    "wof:geomhash":"6d285fcd57dbe4f07d29c9d5311eafb0",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -358,7 +364,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690856162,
+    "wof:lastmodified":1695884946,
     "wof:name":"Guarda",
     "wof:parent_id":85633735,
     "wof:placetype":"region",

--- a/data/856/874/01/85687401.geojson
+++ b/data/856/874/01/85687401.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.534567,
-    "geom:area_square_m":5003804146.008018,
+    "geom:area_square_m":5003804897.481418,
     "geom:bbox":"-8.359178,40.322639,-7.30457,41.21466",
     "geom:latitude":40.798879,
     "geom:longitude":-7.870902,
@@ -335,12 +335,18 @@
         "gn:id":2732264,
         "gp:id":2346580,
         "hasc:id":"PT.VI",
+        "iso:code":"PT-18",
         "iso:id":"PT-18",
+        "qs:local_id":"118",
         "unlc:id":"PT-18",
         "wd:id":"Q273525"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"PT",
-    "wof:geomhash":"00412b358ccb27e0c6b88ac69afc5e41",
+    "wof:geomhash":"0a06cc1e0bd76848bc604166fa1c9cbc",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -355,7 +361,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690856158,
+    "wof:lastmodified":1695884946,
     "wof:name":"Viseu",
     "wof:parent_id":85633735,
     "wof:placetype":"region",

--- a/data/856/874/09/85687409.geojson
+++ b/data/856/874/09/85687409.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.298998,
-    "geom:area_square_m":2801919305.93598,
+    "geom:area_square_m":2801919244.782163,
     "geom:bbox":"-8.783322,40.278817,-8.089172,41.080129",
     "geom:latitude":40.724055,
     "geom:longitude":-8.46867,
@@ -306,12 +306,18 @@
         "gn:id":2742610,
         "gp:id":2346562,
         "hasc:id":"PT.AV",
+        "iso:code":"PT-01",
         "iso:id":"PT-01",
+        "qs:local_id":"101",
         "unlc:id":"PT-01",
         "wd:id":"Q210527"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"PT",
-    "wof:geomhash":"eef86d3c1ada5fb89c1396378103945b",
+    "wof:geomhash":"5b37413aaaf060d75d1c7bafae24dadc",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -326,7 +332,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690856158,
+    "wof:lastmodified":1695884946,
     "wof:name":"Aveiro",
     "wof:parent_id":85633735,
     "wof:placetype":"region",

--- a/data/856/874/11/85687411.geojson
+++ b/data/856/874/11/85687411.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.250654,
-    "geom:area_square_m":2331140655.351636,
+    "geom:area_square_m":2331140248.063951,
     "geom:bbox":"-8.789093,41.001381,-7.875596,41.470978",
     "geom:latitude":41.224797,
     "geom:longitude":-8.353099,
@@ -307,11 +307,17 @@
         "gn:id":2735941,
         "gp:id":2346575,
         "hasc:id":"PT.PO",
+        "iso:code":"PT-13",
         "iso:id":"PT-13",
+        "qs:local_id":"113",
         "wd:id":"Q322792"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"PT",
-    "wof:geomhash":"e8c3106000a61d3f616899de46a01b16",
+    "wof:geomhash":"4cc10a8c7cc553814031a0d05f8dc7f4",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -326,7 +332,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690856157,
+    "wof:lastmodified":1695884946,
     "wof:name":"Porto",
     "wof:parent_id":85633735,
     "wof:placetype":"region",

--- a/data/856/874/15/85687415.geojson
+++ b/data/856/874/15/85687415.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.711389,
-    "geom:area_square_m":6587150394.516262,
+    "geom:area_square_m":6587150892.443035,
     "geom:bbox":"-7.431888,41.024633,-6.189352,41.992531",
     "geom:latitude":41.509445,
     "geom:longitude":-6.859318,
@@ -309,12 +309,18 @@
         "gn:id":2742026,
         "gp:id":2346565,
         "hasc:id":"PT.BA",
+        "iso:code":"PT-04",
         "iso:id":"PT-04",
+        "qs:local_id":"104",
         "unlc:id":"PT-04",
         "wd:id":"Q373528"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"PT",
-    "wof:geomhash":"276ffbf33589359951a1062dd8968d45",
+    "wof:geomhash":"ac6a6e45a9ae10a788a4487fccb1f571",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -329,7 +335,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690856159,
+    "wof:lastmodified":1695884535,
     "wof:name":"Bragan\u00e7a",
     "wof:parent_id":85633735,
     "wof:placetype":"region",

--- a/data/856/874/19/85687419.geojson
+++ b/data/856/874/19/85687419.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.292107,
-    "geom:area_square_m":2702981168.959774,
+    "geom:area_square_m":2702981182.336389,
     "geom:bbox":"-8.810104,41.318835,-7.810671,41.820614",
     "geom:latitude":41.552957,
     "geom:longitude":-8.309868,
@@ -342,12 +342,18 @@
         "gn:id":2742031,
         "gp:id":2346564,
         "hasc:id":"PT.BR",
+        "iso:code":"PT-03",
         "iso:id":"PT-03",
+        "qs:local_id":"103",
         "unlc:id":"PT-03",
         "wd:id":"Q326203"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"PT",
-    "wof:geomhash":"6c603f7471da9a2ff4f58982e56b4bd5",
+    "wof:geomhash":"f988e4c0584e64e3ad9959e43ef0eef3",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -362,7 +368,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690856158,
+    "wof:lastmodified":1695884946,
     "wof:name":"Braga",
     "wof:parent_id":85633735,
     "wof:placetype":"region",

--- a/data/856/874/23/85687423.geojson
+++ b/data/856/874/23/85687423.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.464972,
-    "geom:area_square_m":4302413843.462297,
+    "geom:area_square_m":4302413824.831895,
     "geom:bbox":"-8.119459,41.118763,-7.170633,41.927387",
     "geom:latitude":41.555053,
     "geom:longitude":-7.631682,
@@ -295,12 +295,18 @@
         "gn:id":2732437,
         "gp:id":2346579,
         "hasc:id":"PT.VR",
+        "iso:code":"PT-17",
         "iso:id":"PT-17",
+        "qs:local_id":"117",
         "unlc:id":"PT-17",
         "wd:id":"Q379372"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"PT",
-    "wof:geomhash":"d309ed463fa7d96e16ad87331b04cde5",
+    "wof:geomhash":"f978e25ef5043d48be3dee501c24f5bd",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -315,7 +321,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690856159,
+    "wof:lastmodified":1695884946,
     "wof:name":"Vila Real",
     "wof:parent_id":85633735,
     "wof:placetype":"region",

--- a/data/856/874/33/85687433.geojson
+++ b/data/856/874/33/85687433.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.240731,
-    "geom:area_square_m":2216339073.52397,
+    "geom:area_square_m":2216339210.99827,
     "geom:bbox":"-8.879675,41.606389,-8.082897,42.154419",
     "geom:latitude":41.877921,
     "geom:longitude":-8.506903,
@@ -298,12 +298,18 @@
         "gn:id":2732772,
         "gp:id":2346578,
         "hasc:id":"PT.VC",
+        "iso:code":"PT-16",
         "iso:id":"PT-16",
+        "qs:local_id":"116",
         "unlc:id":"PT-16",
         "wd:id":"Q326214"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"PT",
-    "wof:geomhash":"de726e28351dc0616c0261a96e9c99d9",
+    "wof:geomhash":"d8e3359633ddd2fa00f0fb10e799e732",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -318,7 +324,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690856157,
+    "wof:lastmodified":1695884946,
     "wof:name":"Viana do Castelo",
     "wof:parent_id":85633735,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.